### PR TITLE
fix: make on_active_commitment idempotent

### DIFF
--- a/ccp/src/prover.rs
+++ b/ccp/src/prover.rs
@@ -62,8 +62,10 @@ impl NoxCCPApi for CCProver {
             &self.cu_provers,
             self.status,
         );
+        self.align_with(roadmap).await?;
         self.status = CCStatus::Running { epoch: new_epoch };
-        self.align_with(roadmap).await
+
+        Ok(())
     }
 
     async fn on_no_active_commitment(&mut self) -> Result<(), Self::Error> {


### PR DESCRIPTION
The problem was in that pre actions in roadmap stops `CCProver` and makes it's state `Idle`, then the next roadmap alignment observes this state and decides to reinitialize the whole state.