### PR TITLE
feat: single state dir

### DIFF
--- a/ccp/src/prover.rs
+++ b/ccp/src/prover.rs
@@ -40,7 +40,7 @@ use crate::status::CCStatus;
 use crate::status::ToCCStatus;
 use crate::utility_thread::UtilityThread;
 
-const PROOF_DIR: &str = "ccp_proofs";
+const PROOF_DIR: &str = "cc_proofs";
 
 pub type CCResult<T> = Result<T, CCProverError>;
 
@@ -96,7 +96,7 @@ impl ToCCStatus for CCProver {
 impl CCProver {
     pub fn new(utility_core_id: LogicalCoreId, config: CCPConfig) -> Self {
         let proof_dir = config.state_dir.join(PROOF_DIR);
-        let proof_cleaner = ProofStorageDrainer::new(proof_dir.clone());
+        let proof_drainer = ProofStorageDrainer::new(proof_dir.clone());
         let utility_thread =
             UtilityThread::spawn(utility_core_id, ProofIdx::zero(), proof_dir, None);
         let cu_prover_config = CUProverConfig {
@@ -111,7 +111,7 @@ impl CCProver {
             cu_prover_config,
             status: CCStatus::Idle,
             utility_thread,
-            proof_drainer: proof_cleaner,
+            proof_drainer,
             state_storage,
         }
     }

--- a/ccp/src/prover/tests.rs
+++ b/ccp/src/prover/tests.rs
@@ -466,6 +466,7 @@ async fn prover_restore_from_state_with_no_proofs() {
 async fn prover_restore_from_state_with_proofs() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
     let proofs_dir = state_dir.path().join("ccp_proofs");
+    tokio::fs::create_dir(&proofs_dir).await.unwrap();
 
     let epoch_params = get_epoch_params();
     let cu_allocation = get_cu_allocation();

--- a/ccp/src/prover/tests.rs
+++ b/ccp/src/prover/tests.rs
@@ -465,7 +465,7 @@ async fn prover_restore_from_state_with_no_proofs() {
 #[test(tokio::test(flavor = "multi_thread", worker_threads = 3))]
 async fn prover_restore_from_state_with_proofs() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
-    let proofs_dir = state_dir.path().join("ccp_proofs");
+    let proofs_dir = state_dir.path().join("cc_proofs");
     tokio::fs::create_dir(&proofs_dir).await.unwrap();
 
     let epoch_params = get_epoch_params();

--- a/ccp/src/prover/tests.rs
+++ b/ccp/src/prover/tests.rs
@@ -16,20 +16,17 @@ use test_log::test;
 
 const GEN_PROOFS_DURATION: Duration = Duration::from_secs(10);
 
-fn get_prover(
-    dir_to_store_proofs: impl Into<PathBuf>,
-    dir_to_store_persistent_state: impl Into<PathBuf>,
-) -> CCProver {
-    let dir_to_store_proofs = dir_to_store_proofs.into();
-    let dir_to_store_persistent_state = dir_to_store_persistent_state.into();
+fn get_prover(proof_dir: impl Into<PathBuf>, state_dir: impl Into<PathBuf>) -> CCProver {
+    let proof_dir = proof_dir.into();
+    let state_dir = state_dir.into();
     let enable_msr = false;
     let config = CCPConfig {
         thread_allocation_policy: ccp_config::ThreadsPerCoreAllocationPolicy::Exact {
             threads_per_physical_core: 1.try_into().unwrap(),
         },
         randomx_flags: RandomXFlags::recommended_full_mem(),
-        dir_to_store_proofs,
-        dir_to_store_persistent_state,
+        proof_dir,
+        state_dir,
         enable_msr,
     };
 
@@ -37,19 +34,19 @@ fn get_prover(
 }
 
 async fn get_prover_from_saved_state(
-    dir_to_store_proofs: impl Into<PathBuf>,
-    dir_to_store_persistent_state: impl Into<PathBuf>,
+    proof_dir: impl Into<PathBuf>,
+    state_dir: impl Into<PathBuf>,
 ) -> CCProver {
-    let dir_to_store_proofs = dir_to_store_proofs.into();
-    let dir_to_store_persistent_state = dir_to_store_persistent_state.into();
+    let proof_dir = proof_dir.into();
+    let state_dir = state_dir.into();
     let enable_msr = false;
     let config = CCPConfig {
         thread_allocation_policy: ccp_config::ThreadsPerCoreAllocationPolicy::Exact {
             threads_per_physical_core: 1.try_into().unwrap(),
         },
         randomx_flags: RandomXFlags::recommended_full_mem(),
-        dir_to_store_proofs,
-        dir_to_store_persistent_state,
+        proof_dir,
+        state_dir,
         enable_msr,
     };
 

--- a/ccp/src/utility_thread/proof_storage.rs
+++ b/ccp/src/utility_thread/proof_storage.rs
@@ -23,6 +23,8 @@ use std::path::PathBuf;
 
 use ccp_shared::proof::CCProof;
 
+use crate::proof_storage::ensure_dir;
+
 const EXPECT_DEFAULT_SERIALIZER: &str = "the default serde serializer shouldn't fail";
 
 #[derive(Debug)]
@@ -38,6 +40,7 @@ impl ProofStorage {
     }
 
     pub async fn store_new_proof(&self, proof: CCProof) -> tokio::io::Result<()> {
+        ensure_dir(&self.proof_directory).await?;
         let proof_as_string = serde_json::to_string(&proof).expect(EXPECT_DEFAULT_SERIALIZER);
         let proof_path = self.proof_directory.join(proof.id.idx.to_string());
         tokio::task::spawn_blocking(move || save_reliably(&proof_path, proof_as_string)).await??;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -34,7 +34,6 @@ use ccp_randomx::RandomXFlags;
 pub struct CCPConfig {
     pub thread_allocation_policy: ThreadsPerCoreAllocationPolicy,
     pub randomx_flags: RandomXFlags,
-    pub proof_dir: PathBuf,
     pub state_dir: PathBuf,
     pub enable_msr: bool,
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -34,8 +34,8 @@ use ccp_randomx::RandomXFlags;
 pub struct CCPConfig {
     pub thread_allocation_policy: ThreadsPerCoreAllocationPolicy,
     pub randomx_flags: RandomXFlags,
-    pub dir_to_store_proofs: PathBuf,
-    pub dir_to_store_persistent_state: PathBuf,
+    pub proof_dir: PathBuf,
+    pub state_dir: PathBuf,
     pub enable_msr: bool,
 }
 

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -62,9 +62,6 @@ struct ProverArgs {
     threads_per_physical_core: std::num::NonZeroUsize,
 
     #[arg(long)]
-    proof_dir: PathBuf,
-
-    #[arg(long)]
     state_dir: PathBuf,
 
     #[arg(long, action = ArgAction::SetTrue)]
@@ -88,11 +85,8 @@ fn main() -> eyre::Result<()> {
         eyre::bail!("please, define at least one --tokio-core-id");
     }
 
-    check_writable_dir(&args.prover_args.proof_dir)
-        .wrap_err("The --proof-dir value should be a writeable directory path")?;
-    check_writable_dir(&args.prover_args.state_dir).wrap_err(
-        "The --state-dir value should be a writeable directory path",
-    )?;
+    check_writable_dir(&args.prover_args.state_dir)
+        .wrap_err("The --state-dir value should be a writeable directory path")?;
 
     #[cfg(target_os = "linux")]
     let tokio_cores = args.tokio_core_ids;
@@ -143,7 +137,6 @@ async fn build_prover(prover_args: ProverArgs) -> eyre::Result<CCProver> {
             threads_per_physical_core: prover_args.threads_per_physical_core,
         },
         randomx_flags,
-        proof_dir: prover_args.proof_dir,
         state_dir: prover_args.state_dir,
         enable_msr: prover_args.enable_msr,
     };


### PR DESCRIPTION
The only directory option is `--state-dir`, and proofs are stored in `ccp_proofs` subdir inside it.