### PR TITLE
feat: background on_commitment handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ dependencies = [
  "capacity-commitment-prover",
  "ccp-rpc-client",
  "ccp-shared",
+ "eyre",
  "jsonrpsee",
  "tokio",
  "tracing",

--- a/ccp/src/prover.rs
+++ b/ccp/src/prover.rs
@@ -183,20 +183,20 @@ impl CCProver {
         Ok(self_)
     }
 
-    async fn save_state(
+    pub async fn save_state(
         &self,
         epoch_state: EpochParameters,
         cu_allocation: CUAllocation,
-    ) -> CCResult<()> {
+    ) -> tokio::io::Result<()> {
         let state = CCPState {
             epoch_params: epoch_state,
             cu_allocation,
         };
-        Ok(self.state_storage.save_state(Some(&state)).await?)
+        self.state_storage.save_state(Some(&state)).await
     }
 
-    async fn save_no_state(&self) -> CCResult<()> {
-        Ok(self.state_storage.save_state(None).await?)
+    pub async fn save_no_state(&self) -> tokio::io::Result<()> {
+        self.state_storage.save_state(None).await
     }
 
     async fn apply_cc_parameters(

--- a/ccp/src/prover.rs
+++ b/ccp/src/prover.rs
@@ -183,20 +183,20 @@ impl CCProver {
         Ok(self_)
     }
 
-    pub async fn save_state(
+    async fn save_state(
         &self,
         epoch_state: EpochParameters,
         cu_allocation: CUAllocation,
-    ) -> tokio::io::Result<()> {
+    ) -> CCResult<()> {
         let state = CCPState {
             epoch_params: epoch_state,
             cu_allocation,
         };
-        self.state_storage.save_state(Some(&state)).await
+        Ok(self.state_storage.save_state(Some(&state)).await?)
     }
 
-    pub async fn save_no_state(&self) -> tokio::io::Result<()> {
-        self.state_storage.save_state(None).await
+    async fn save_no_state(&self) -> CCResult<()> {
+        Ok(self.state_storage.save_state(None).await?)
     }
 
     async fn apply_cc_parameters(

--- a/ccp/src/prover.rs
+++ b/ccp/src/prover.rs
@@ -62,7 +62,7 @@ impl NoxCCPApi for CCProver {
         self.apply_cc_parameters(new_epoch, &new_allocation).await?;
         // Save data only if align_with is successful; otherwise invalid commitment will be stored
         // and used on restart to fail again.
-        self.save_state(new_epoch, new_allocation).await
+        Ok(self.save_state(new_epoch, new_allocation).await?)
     }
 
     async fn on_no_active_commitment(&mut self) -> Result<(), Self::Error> {

--- a/ccp/src/prover.rs
+++ b/ccp/src/prover.rs
@@ -62,7 +62,7 @@ impl NoxCCPApi for CCProver {
         self.apply_cc_parameters(new_epoch, &new_allocation).await?;
         // Save data only if align_with is successful; otherwise invalid commitment will be stored
         // and used on restart to fail again.
-        Ok(self.save_state(new_epoch, new_allocation).await?)
+        self.save_state(new_epoch, new_allocation).await
     }
 
     async fn on_no_active_commitment(&mut self) -> Result<(), Self::Error> {

--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -21,3 +21,4 @@ async-trait.workspace = true
 jsonrpsee.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+eyre.workspace = true

--- a/crates/rpc-server/src/facade.rs
+++ b/crates/rpc-server/src/facade.rs
@@ -29,14 +29,14 @@ use ccp_shared::types::CUAllocation;
 use ccp_shared::types::EpochParameters;
 use tokio::task::JoinHandle;
 
-/// An async façade for RPC.
-pub struct OfflineFacade<P> {
+/// An façade that handles RPC calls in background.
+pub struct BackgroundFacade<P> {
     to_worker: mpsc::Sender<FacadeMessage>,
     prover: Arc<RwLock<P>>,
     worker: JoinHandle<()>,
 }
 
-impl<P> OfflineFacade<P>
+impl<P> BackgroundFacade<P>
 where
     P: NoxCCPApi + Sync + 'static,
     <P as NoxCCPApi>::Error: Display,
@@ -66,7 +66,7 @@ enum FacadeMessage {
     OnNoCommitment,
 }
 
-impl<P: NoxCCPApi> NoxCCPApi for OfflineFacade<P>
+impl<P: NoxCCPApi> NoxCCPApi for BackgroundFacade<P>
 where
     P: Sync,
     <P as NoxCCPApi>::Error: Display,

--- a/crates/rpc-server/src/facade.rs
+++ b/crates/rpc-server/src/facade.rs
@@ -21,14 +21,13 @@ use eyre::Context;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::RwLock;
-use tokio::task::JoinHandle;
 
-use capacity_commitment_prover::CCProver;
 use ccp_shared::nox_ccp_api::NoxCCPApi;
 use ccp_shared::proof::CCProof;
 use ccp_shared::proof::ProofIdx;
 use ccp_shared::types::CUAllocation;
 use ccp_shared::types::EpochParameters;
+use tokio::task::JoinHandle;
 
 /// An façade that handles RPC calls in background.
 pub struct BackgroundFacade<P> {
@@ -67,8 +66,11 @@ enum FacadeMessage {
     OnNoCommitment,
 }
 
-// implement for specific prover to implement granular state saving
-impl NoxCCPApi for BackgroundFacade<CCProver> {
+impl<P: NoxCCPApi> NoxCCPApi for BackgroundFacade<P>
+where
+    P: Sync,
+    <P as NoxCCPApi>::Error: Display,
+{
     type Error = eyre::Error;
 
     async fn on_active_commitment(
@@ -76,15 +78,6 @@ impl NoxCCPApi for BackgroundFacade<CCProver> {
         epoch_parameters: EpochParameters,
         cu_allocation: CUAllocation,
     ) -> Result<(), Self::Error> {
-        // Save state early so that caller is sure it is saved.
-        // Please note that the caller may be still stuck if dataset generation
-        // is in progress and writer lock is held.
-        {
-            let guard = self.prover.read().await;
-            guard
-                .save_state(epoch_parameters, cu_allocation.clone())
-                .await?;
-        }
         self.to_worker
             .try_send(FacadeMessage::OnActiveCommitment(
                 epoch_parameters,
@@ -94,13 +87,6 @@ impl NoxCCPApi for BackgroundFacade<CCProver> {
     }
 
     async fn on_no_active_commitment(&mut self) -> Result<(), Self::Error> {
-        // Save state early so that caller is sure it is saved.
-        // Please note that the caller may be still stuck if dataset generation
-        // is in progress and writer lock is held.
-        {
-            let guard = self.prover.read().await;
-            guard.save_no_state().await?;
-        }
         self.to_worker
             .send(FacadeMessage::OnNoCommitment)
             .await

--- a/crates/rpc-server/src/facade.rs
+++ b/crates/rpc-server/src/facade.rs
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ccp_shared::nox_ccp_api::NoxCCPApi;
+use ccp_shared::proof::CCProof;
+use ccp_shared::proof::ProofIdx;
+use ccp_shared::types::CUAllocation;
+use ccp_shared::types::EpochParameters;
+
+use eyre::Context;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TryRecvError;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+
+const WAIT_LOCK_DURATION: Duration = Duration::from_secs(2);
+
+/// An async façade for RPC.
+pub struct OfflineFacade<P> {
+    sender_to_worker: mpsc::Sender<FacadeMessage>,
+    prover: Arc<Mutex<P>>,
+}
+
+impl<P> OfflineFacade<P>
+where
+    P: NoxCCPApi + 'static,
+    <P as NoxCCPApi>::Error: ToString,
+{
+    pub fn new(prover: P) -> Self {
+        let prover = Arc::new(Mutex::new(prover));
+
+        let (sender_to_worker, receiver) = mpsc::channel(100);
+
+        let _worker = tokio::task::spawn(facade_loop(prover.clone(), receiver));
+
+        Self {
+            sender_to_worker,
+            prover,
+        }
+    }
+}
+
+enum FacadeMessage {
+    OnActiveCommitment(EpochParameters, CUAllocation),
+    OnNoCommitment,
+}
+
+impl<P: NoxCCPApi> NoxCCPApi for OfflineFacade<P>
+where
+    <P as NoxCCPApi>::Error: ToString,
+{
+    type Error = eyre::Error;
+
+    async fn on_active_commitment(
+        &mut self,
+        epoch_parameters: EpochParameters,
+        cu_allocation: CUAllocation,
+    ) -> Result<(), Self::Error> {
+        self.sender_to_worker
+            .try_send(FacadeMessage::OnActiveCommitment(
+                epoch_parameters,
+                cu_allocation,
+            ))
+            .context("on_active_commitment")
+    }
+
+    async fn on_no_active_commitment(&mut self) -> Result<(), Self::Error> {
+        self.sender_to_worker
+            .send(FacadeMessage::OnNoCommitment)
+            .await
+            .context("on_no_active_commitment")
+    }
+
+    async fn get_proofs_after(&self, proof_idx: ProofIdx) -> Result<Vec<CCProof>, Self::Error> {
+        let guard = match timeout(WAIT_LOCK_DURATION, self.prover.lock()).await {
+            Ok(g) => g,
+            Err(e) => {
+                return Err(e).context("failed to get lock in get_proofs_after: lock is still busy")
+            }
+        };
+        guard
+            .get_proofs_after(proof_idx)
+            .await
+            // CCProverError is not Sync, so we convert it to a string in situ
+            .map_err(|e| eyre::eyre!(e.to_string()))
+            .context("get_proofs_after")
+    }
+}
+
+async fn facade_loop<P>(prover: Arc<Mutex<P>>, mut receiver: mpsc::Receiver<FacadeMessage>)
+where
+    P: NoxCCPApi,
+    <P as NoxCCPApi>::Error: ToString,
+{
+    use FacadeMessage::*;
+    while let Some(message) = receive_last(&mut receiver).await {
+        let mut guard = prover.lock().await;
+        match message {
+            OnActiveCommitment(epoch_parameters, cu_allocation) => {
+                let res = guard
+                    .on_active_commitment(epoch_parameters, cu_allocation)
+                    .await;
+                if let Err(e) = res {
+                    tracing::error!("nested prover on_active_commitment failed: {e:?}");
+                }
+            }
+            OnNoCommitment => {
+                let res = guard.on_no_active_commitment().await;
+                if let Err(e) = res {
+                    tracing::error!("nested prover on_no_active_commitment failed: {e:?}");
+                }
+            }
+        }
+    }
+}
+
+async fn receive_last<T>(receiver: &mut mpsc::Receiver<T>) -> Option<T> {
+    // wating for a new value
+    let mut val = receiver.recv().await?;
+    //  non-wating getting of the last available value
+    loop {
+        match receiver.try_recv() {
+            Ok(v) => {
+                val = v;
+            }
+            Err(TryRecvError::Empty) => {
+                return Some(val);
+            }
+            Err(TryRecvError::Disconnected) => {
+                return None;
+            }
+        }
+    }
+}

--- a/crates/rpc-server/src/facade.rs
+++ b/crates/rpc-server/src/facade.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use std::fmt::Display;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -40,7 +41,7 @@ pub struct OfflineFacade<P> {
 impl<P> OfflineFacade<P>
 where
     P: NoxCCPApi + 'static,
-    <P as NoxCCPApi>::Error: ToString,
+    <P as NoxCCPApi>::Error: Display,
 {
     pub fn new(prover: P) -> Self {
         let prover = Arc::new(Mutex::new(prover));
@@ -63,7 +64,7 @@ enum FacadeMessage {
 
 impl<P: NoxCCPApi> NoxCCPApi for OfflineFacade<P>
 where
-    <P as NoxCCPApi>::Error: ToString,
+    <P as NoxCCPApi>::Error: Display,
 {
     type Error = eyre::Error;
 
@@ -106,7 +107,7 @@ where
 async fn facade_loop<P>(prover: Arc<Mutex<P>>, mut receiver: mpsc::Receiver<FacadeMessage>)
 where
     P: NoxCCPApi,
-    <P as NoxCCPApi>::Error: ToString,
+    <P as NoxCCPApi>::Error: Display,
 {
     use FacadeMessage::*;
     while let Some(message) = receive_last(&mut receiver).await {
@@ -117,13 +118,13 @@ where
                     .on_active_commitment(epoch_parameters, cu_allocation)
                     .await;
                 if let Err(e) = res {
-                    tracing::error!("nested prover on_active_commitment failed: {e:?}");
+                    tracing::error!("nested prover on_active_commitment failed: {e}");
                 }
             }
             OnNoCommitment => {
                 let res = guard.on_no_active_commitment().await;
                 if let Err(e) = res {
-                    tracing::error!("nested prover on_no_active_commitment failed: {e:?}");
+                    tracing::error!("nested prover on_no_active_commitment failed: {e}");
                 }
             }
         }

--- a/crates/rpc-server/src/lib.rs
+++ b/crates/rpc-server/src/lib.rs
@@ -50,7 +50,7 @@ use ccp_shared::types::GlobalNonce;
 use ccp_shared::types::PhysicalCoreId;
 use ccp_shared::types::CUID;
 
-pub use crate::facade::OfflineFacade;
+pub use crate::facade::BackgroundFacade;
 
 pub struct CCPRcpHttpServer<P> {
     // n.b. if NoxCCPApi would have internal mutability, we might get used of the Mutex

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -28,12 +28,11 @@
 
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
 
+use ccp_rpc_server::OfflineFacade;
 use clap::ArgAction;
 use clap::Parser;
 use eyre::WrapErr as _;
-use tokio::sync::Mutex;
 use tracing_subscriber::EnvFilter;
 
 use capacity_commitment_prover::CCProver;
@@ -123,7 +122,7 @@ async fn async_main(bind_address: String, prover_args: ProverArgs) -> eyre::Resu
     tracing::info!("created prover");
 
     // Launch RPC API
-    let rpc_server = CCPRcpHttpServer::new(Arc::new(Mutex::new(prover)));
+    let rpc_server = CCPRcpHttpServer::new(OfflineFacade::new(prover));
     tracing::info!("starting an RPC server");
     let server_handle = rpc_server
         .run_server(bind_address)

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -29,7 +29,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
-use ccp_rpc_server::OfflineFacade;
+use ccp_rpc_server::BackgroundFacade;
 use clap::ArgAction;
 use clap::Parser;
 use eyre::WrapErr as _;
@@ -122,7 +122,7 @@ async fn async_main(bind_address: String, prover_args: ProverArgs) -> eyre::Resu
     tracing::info!("created prover");
 
     // Launch RPC API
-    let rpc_server = CCPRcpHttpServer::new(OfflineFacade::new(prover));
+    let rpc_server = CCPRcpHttpServer::new(BackgroundFacade::new(prover));
     tracing::info!("starting an RPC server");
     let server_handle = rpc_server
         .run_server(bind_address)


### PR DESCRIPTION
An RPC client doesn't have to wait for data generation.  When multiple requests are submitted, only last one is effective.