### PR TITLE
feat(msr, persistance): vm 513 msr persistance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,8 @@ dependencies = [
  "nix",
  "once_cell",
  "raw-cpuid",
+ "serde",
+ "serde_json",
  "thiserror",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 name = "ccp-config"
 version = "0.1.0"
 dependencies = [
+ "ccp-msr",
  "ccp-randomx",
  "ccp-shared",
  "config",

--- a/ccp/src/cu/config.rs
+++ b/ccp/src/cu/config.rs
@@ -17,6 +17,7 @@
 use ccp_config::Optimizations;
 use ccp_config::RandomXFlags;
 use ccp_config::ThreadsPerCoreAllocationPolicy;
+use ccp_msr::MSRConfig;
 
 #[derive(Clone, Debug)]
 pub struct CUProverConfig {
@@ -24,8 +25,8 @@ pub struct CUProverConfig {
     /// Defines how many threads will be assigned to a specific physical core,
     /// aims to utilize benefits of hyper-threading.
     pub threads_per_core_policy: ThreadsPerCoreAllocationPolicy,
-    /// Control to enable MSR-based performance optimization.
-    pub msr_enabled: bool,
+    /// Controls MSR-based performance optimization state and stores original MSR registers values.
+    pub msr_config: MSRConfig,
 }
 
 impl From<Optimizations> for CUProverConfig {

--- a/ccp/src/cu/config.rs
+++ b/ccp/src/cu/config.rs
@@ -34,7 +34,7 @@ impl From<Optimizations> for CUProverConfig {
         Self {
             randomx_flags: ccp_optimizations.randomx_flags,
             threads_per_core_policy: ccp_optimizations.threads_per_core_policy,
-            msr_enabled: ccp_optimizations.msr_enabled,
+            msr_config: ccp_optimizations.msr_config,
         }
     }
 }

--- a/ccp/src/cu/cu_prover.rs
+++ b/ccp/src/cu/cu_prover.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use ccp_msr::MSRConfig;
 use ccp_randomx::cache::CacheHandle;
 use ccp_randomx::dataset::DatasetHandle;
 use ccp_randomx::Dataset;
@@ -44,16 +43,6 @@ pub struct CUProver {
     status: CUStatus,
 }
 
-#[derive(Clone, Debug)]
-pub struct CUProverConfig {
-    pub randomx_flags: RandomXFlags,
-    /// Defines how many threads will be assigned to a specific physical core,
-    /// aims to utilize benefits of hyper-threading.
-    pub thread_allocation_policy: ThreadsPerCoreAllocationPolicy,
-    /// Controls MSR-based performance optimization state and stores original MSR registers values.
-    pub msr_config: MSRConfig,
-}
-
 impl CUProver {
     pub(crate) async fn create(
         config: CUProverConfig,
@@ -61,9 +50,8 @@ impl CUProver {
         core_id: PhysicalCoreId,
     ) -> CUResult<Self> {
         let topology = CPUTopology::new()?;
-        let mut threads =
-            ThreadAllocator::new(config.thread_allocation_policy, core_id, &topology)?
-                .allocate(to_utility, config.msr_config)?;
+        let mut threads = ThreadAllocator::new(config.threads_per_core_policy, core_id, &topology)?
+            .allocate(to_utility, config.msr_config)?;
 
         let thread = &mut threads.head;
         let dataset = thread.allocate_dataset(config.randomx_flags).await?;

--- a/ccp/src/cu/proving_thread/async_/thread.rs
+++ b/ccp/src/cu/proving_thread/async_/thread.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use ccp_msr::MSRConfig;
 use tokio::sync::mpsc;
 
 use ccp_msr::MSRImpl;
@@ -43,13 +44,13 @@ impl ProvingThreadAsync {
     pub(crate) fn new(
         core_id: LogicalCoreId,
         to_utility: ToUtilityInlet,
-        msr_enabled: bool,
+        msr_config: MSRConfig,
     ) -> Self {
         let (to_sync, from_async) = mpsc::channel::<AsyncToSyncMessage>(1);
         let (to_async, from_sync) = mpsc::channel::<SyncToAsyncMessage>(1);
         let sync_thread = ProvingThreadSync::spawn(core_id, from_async, to_async, to_utility);
-        let mut msr = MSRImpl::new(msr_enabled, core_id);
-        let _ = msr.write_preset(true);
+        let mut msr = MSRImpl::new(msr_config, core_id);
+        let _ = msr.write_preset();
 
         Self {
             to_sync,

--- a/ccp/src/cu/proving_thread/tests.rs
+++ b/ccp/src/cu/proving_thread/tests.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use ccp_msr::MSRConfig;
 use tokio::sync::mpsc;
 
 use ccp_randomx::dataset::DatasetHandle;
@@ -45,7 +44,7 @@ impl ThreadInitIngredients {
 
         let (inlet, outlet) = mpsc::channel(1);
 
-        let mut thread = ProvingThreadAsync::new(core_id, inlet, MSRConfig::disabled_msr());
+        let mut thread = ProvingThreadAsync::new(core_id, inlet, <_>::default());
         let dataset = thread.allocate_dataset(flags).await.unwrap();
         let cache = thread.create_cache(epoch, cu_id, flags).await.unwrap();
         thread
@@ -76,7 +75,7 @@ async fn cache_creation_works() {
     let flags = RandomXFlags::recommended();
 
     let (inlet, _outlet) = mpsc::channel(1);
-    let mut thread = ProvingThreadAsync::new(2.into(), inlet, MSRConfig::disabled_msr());
+    let mut thread = ProvingThreadAsync::new(2.into(), inlet, <_>::default());
     let actual_cache = thread.create_cache(epoch, cu_id, flags).await.unwrap();
     thread.stop().await.unwrap();
 
@@ -99,7 +98,7 @@ async fn dataset_creation_works() {
     let flags = RandomXFlags::recommended_full_mem();
 
     let (inlet, mut outlet) = mpsc::channel(1);
-    let mut thread = ProvingThreadAsync::new(2.into(), inlet, MSRConfig::disabled_msr());
+    let mut thread = ProvingThreadAsync::new(2.into(), inlet, <_>::default());
     let actual_dataset = thread.allocate_dataset(flags).await.unwrap();
     let actual_cache = thread.create_cache(epoch, cu_id, flags).await.unwrap();
     thread
@@ -147,11 +146,7 @@ async fn dataset_creation_works_with_three_threads() {
 
     let mut threads = (0..threads_count)
         .map(|thread_id| {
-            ProvingThreadAsync::new(
-                (2 + thread_id).into(),
-                inlet.clone(),
-                MSRConfig::disabled_msr(),
-            )
+            ProvingThreadAsync::new((2 + thread_id).into(), inlet.clone(), <_>::default())
         })
         .collect::<Vec<_>>();
 

--- a/ccp/src/cu/proving_thread_utils/allocator.rs
+++ b/ccp/src/cu/proving_thread_utils/allocator.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use ccp_msr::MSRConfig;
 use nonempty::NonEmpty;
 
 use ccp_config::ThreadsPerCoreAllocationPolicy;
@@ -49,13 +50,13 @@ impl ThreadAllocator {
     pub(crate) fn allocate(
         &self,
         to_utility: ToUtilityInlet,
-        msr_enabled: bool,
+        msr_config: MSRConfig,
     ) -> CUResult<NonEmpty<ProvingThreadAsync>> {
         let threads = self
             .allocation_strategy
             .iter()
             .map(|logical_core| {
-                ProvingThreadAsync::new(*logical_core, to_utility.clone(), msr_enabled)
+                ProvingThreadAsync::new(*logical_core, to_utility.clone(), msr_config.clone())
             })
             .collect::<Vec<_>>();
         let threads = NonEmpty::from_vec(threads).unwrap();

--- a/ccp/src/cu/tests.rs
+++ b/ccp/src/cu/tests.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use ccp_msr::MSRConfig;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 
@@ -81,7 +82,7 @@ fn create_config(cores_count: usize) -> CUProverConfig {
         threads_per_core_policy: ThreadsPerCoreAllocationPolicy::Exact {
             threads_per_physical_core: std::num::NonZeroUsize::new(cores_count).unwrap(),
         },
-        msr_enabled: false,
+        msr_config: MSRConfig::disabled_msr(),
     }
 }
 

--- a/ccp/src/cu/tests.rs
+++ b/ccp/src/cu/tests.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use ccp_msr::MSRConfig;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 
@@ -82,7 +81,7 @@ fn create_config(cores_count: usize) -> CUProverConfig {
         threads_per_core_policy: ThreadsPerCoreAllocationPolicy::Exact {
             threads_per_physical_core: std::num::NonZeroUsize::new(cores_count).unwrap(),
         },
-        msr_config: MSRConfig::disabled_msr(),
+        msr_config: <_>::default(),
     }
 }
 

--- a/ccp/src/prover.rs
+++ b/ccp/src/prover.rs
@@ -205,21 +205,6 @@ impl CCProver {
             config.optimizations
         };
 
-        let original_msr_preset = if config.enable_msr {
-            prev_state
-                .as_ref()
-                .map_or_else(get_original_cpu_msr_preset, |state| {
-                    state.msr_config.original_msr_preset.clone()
-                })
-        } else {
-            MSRCpuPreset::empty()
-        };
-
-        let msr_config = MSRConfig {
-            enable_msr: config.enable_msr,
-            original_msr_preset,
-        };
-
         let hashrate_collector = Arc::new(Mutex::new(HashrateCollector::new()));
         let hashrate_handler = HashrateHandler::new(
             hashrate_collector.clone(),

--- a/ccp/src/prover/tests.rs
+++ b/ccp/src/prover/tests.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use ccp_config::CCPConfig;
+use ccp_msr::MSRConfig;
 use ccp_randomx::ResultHash;
 use ccp_shared::proof::{CCProof, CCProofId, ProofIdx};
 use ccp_shared::types::LocalNonce;
@@ -96,9 +97,11 @@ async fn prover_on_active_commitment() {
         .unwrap();
 
     let state = load_state(state_dir.path());
-    let expected_state = Some(CCPState {
+
+    let expected_state: Option<CCPState> = Some(CCPState {
         epoch_params,
         cu_allocation: cu_allocation.clone(),
+        msr_config: MSRConfig::disabled_msr(),
     });
 
     tokio::time::sleep(GEN_PROOFS_DURATION).await;
@@ -384,6 +387,7 @@ async fn prover_on_active_change_epoch() {
     let expected_state = Some(CCPState {
         epoch_params: epoch_params_second,
         cu_allocation: cu_allocation.clone(),
+        msr_config: MSRConfig::disabled_msr(),
     });
 
     tokio::time::sleep(GEN_PROOFS_DURATION).await;
@@ -430,6 +434,7 @@ async fn prover_restore_from_state_with_no_proofs() {
     let initial_state = Some(CCPState {
         epoch_params,
         cu_allocation: cu_allocation.clone(),
+        msr_config: MSRConfig::disabled_msr(),
     });
     tokio::fs::write(state_path, &serde_json::to_vec(&initial_state).unwrap())
         .await
@@ -494,6 +499,7 @@ async fn prover_restore_from_state_with_proofs() {
     let initial_state = Some(CCPState {
         epoch_params,
         cu_allocation: cu_allocation.clone(),
+        msr_config: MSRConfig::disabled_msr(),
     });
     tokio::fs::write(state_path, &serde_json::to_vec(&initial_state).unwrap())
         .await

--- a/ccp/src/prover/tests.rs
+++ b/ccp/src/prover/tests.rs
@@ -19,7 +19,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use ccp_config::CCPConfig;
-use ccp_msr::MSRConfig;
 use ccp_randomx::ResultHash;
 use ccp_shared::proof::{CCProof, CCProofId, ProofIdx};
 use ccp_shared::types::LocalNonce;
@@ -101,7 +100,7 @@ async fn prover_on_active_commitment() {
     let expected_state: Option<CCPState> = Some(CCPState {
         epoch_params,
         cu_allocation: cu_allocation.clone(),
-        msr_config: MSRConfig::disabled_msr(),
+        msr_config: <_>::default(),
     });
 
     tokio::time::sleep(GEN_PROOFS_DURATION).await;
@@ -387,7 +386,7 @@ async fn prover_on_active_change_epoch() {
     let expected_state = Some(CCPState {
         epoch_params: epoch_params_second,
         cu_allocation: cu_allocation.clone(),
-        msr_config: MSRConfig::disabled_msr(),
+        msr_config: <_>::default(),
     });
 
     tokio::time::sleep(GEN_PROOFS_DURATION).await;
@@ -434,7 +433,7 @@ async fn prover_restore_from_state_with_no_proofs() {
     let initial_state = Some(CCPState {
         epoch_params,
         cu_allocation: cu_allocation.clone(),
-        msr_config: MSRConfig::disabled_msr(),
+        msr_config: <_>::default(),
     });
     tokio::fs::write(state_path, &serde_json::to_vec(&initial_state).unwrap())
         .await
@@ -499,7 +498,7 @@ async fn prover_restore_from_state_with_proofs() {
     let initial_state = Some(CCPState {
         epoch_params,
         cu_allocation: cu_allocation.clone(),
-        msr_config: MSRConfig::disabled_msr(),
+        msr_config: <_>::default(),
     });
     tokio::fs::write(state_path, &serde_json::to_vec(&initial_state).unwrap())
         .await

--- a/ccp/src/state_storage.rs
+++ b/ccp/src/state_storage.rs
@@ -35,6 +35,7 @@ pub(crate) struct StateStorage {
 pub(crate) struct CCPState {
     pub(crate) epoch_params: EpochParameters,
     pub(crate) cu_allocation: CUAllocation,
+    pub(crate) msr_config: ccp_msr::MSRConfig,
 }
 
 impl StateStorage {

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 ccp-randomx.workspace = true
 ccp-shared.workspace = true
+ccp-msr.workspace = true
 
 config.workspace = true
 eyre.workspace = true

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+use ccp_msr::MSRConfig;
 use ccp_randomx::RandomXFlags;
 use ccp_shared::types::LogicalCoreId;
 
 use crate::defaults::default_log_level;
-use crate::defaults::default_msr_enabled;
 use crate::defaults::default_report_hashrate;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -47,7 +47,7 @@ pub struct PrometheusEndpoint {
 pub struct Optimizations {
     pub randomx_flags: RandomXFlags,
     pub threads_per_core_policy: ThreadsPerCoreAllocationPolicy,
-    pub msr_enabled: bool,
+    pub msr_config: MSRConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -88,7 +88,7 @@ impl Default for Optimizations {
         Self {
             randomx_flags: RandomXFlags::recommended_full_mem(),
             threads_per_core_policy: <_>::default(),
-            msr_enabled: default_msr_enabled(),
+            msr_config: MSRConfig::disabled_msr(),
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -88,7 +88,7 @@ impl Default for Optimizations {
         Self {
             randomx_flags: RandomXFlags::recommended_full_mem(),
             threads_per_core_policy: <_>::default(),
-            msr_config: MSRConfig::disabled_msr(),
+            msr_config: <_>::default(),
         }
     }
 }

--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
+use ccp_msr::MSRConfig;
+
 use crate::unresolved_config::LogLevel;
 
-pub(crate) fn default_msr_enabled() -> bool {
-    false
+pub(crate) fn default_msr_enabled() -> MSRConfig {
+    use ccp_msr::get_original_cpu_msr_preset;
+
+    MSRConfig::new(true, get_original_cpu_msr_preset())
 }
 
 pub(crate) fn default_log_level() -> LogLevel {

--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-use ccp_msr::MSRConfig;
-
 use crate::unresolved_config::LogLevel;
-
-pub(crate) fn default_msr_enabled() -> MSRConfig {
-    use ccp_msr::get_original_cpu_msr_preset;
-
-    MSRConfig::new(true, get_original_cpu_msr_preset())
-}
 
 pub(crate) fn default_log_level() -> LogLevel {
     LogLevel::Error

--- a/crates/config/src/tests/tests_.rs
+++ b/crates/config/src/tests/tests_.rs
@@ -16,7 +16,6 @@
 
 use std::path::PathBuf;
 
-use ccp_msr::MSRConfig;
 use ccp_randomx::RandomXFlags;
 
 use crate::config_loader::load_config;
@@ -52,7 +51,7 @@ fn parse_basic_config() {
         threads_per_core_policy: ThreadsPerCoreAllocationPolicy::Exact {
             threads_per_physical_core: 2.try_into().unwrap(),
         },
-        msr_config: MSRConfig::disabled_msr(),
+        msr_config: <_>::default(),
     };
     let logs = Logs {
         report_hashrate: true,
@@ -87,7 +86,7 @@ fn parse_config_without_optimiziations() {
     let optimizations = Optimizations {
         randomx_flags,
         threads_per_core_policy: ThreadsPerCoreAllocationPolicy::Optimal,
-        msr_enabled: false,
+        msr_config: <_>::default(),
     };
     let logs = Logs {
         report_hashrate: true,

--- a/crates/config/src/tests/tests_.rs
+++ b/crates/config/src/tests/tests_.rs
@@ -16,6 +16,7 @@
 
 use std::path::PathBuf;
 
+use ccp_msr::MSRConfig;
 use ccp_randomx::RandomXFlags;
 
 use crate::config_loader::load_config;
@@ -51,7 +52,7 @@ fn parse_basic_config() {
         threads_per_core_policy: ThreadsPerCoreAllocationPolicy::Exact {
             threads_per_physical_core: 2.try_into().unwrap(),
         },
-        msr_enabled: true,
+        msr_config: MSRConfig::disabled_msr(),
     };
     let logs = Logs {
         report_hashrate: true,

--- a/crates/config/src/unresolved_config.rs
+++ b/crates/config/src/unresolved_config.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use ccp_msr::MSRConfig;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -57,7 +58,7 @@ pub struct UnresolvedOptimizations {
     pub randomx: UnresolvedRandomX,
 
     #[serde(default = "default_msr_enabled")]
-    pub msr_enabled: bool,
+    pub msr_config: MSRConfig,
 
     pub threads_per_core: Option<usize>,
 }
@@ -156,7 +157,7 @@ impl UnresolvedPrometheusEndpoint {
 impl UnresolvedOptimizations {
     pub fn resolve(self) -> eyre::Result<Optimizations> {
         let randomx_flags = self.randomx.resolve();
-        let msr_enabled = self.msr_enabled;
+        let msr_config = self.msr_config;
         let threads_per_core_policy = match self.threads_per_core {
             Some(threads_count) => ThreadsPerCoreAllocationPolicy::Exact {
                 threads_per_physical_core: threads_count.try_into()?,
@@ -166,7 +167,7 @@ impl UnresolvedOptimizations {
 
         let opt = Optimizations {
             randomx_flags,
-            msr_enabled,
+            msr_config,
             threads_per_core_policy,
         };
         Ok(opt)

--- a/crates/config/src/unresolved_config.rs
+++ b/crates/config/src/unresolved_config.rs
@@ -17,9 +17,6 @@
 use serde::Deserialize;
 use serde::Serialize;
 
-use ccp_randomx::RandomXFlags;
-
-use super::config::Optimizations;
 use super::defaults::default_log_level;
 use super::defaults::default_msr_enabled;
 use super::defaults::default_report_hashrate;

--- a/crates/config/src/unresolved_config.rs
+++ b/crates/config/src/unresolved_config.rs
@@ -19,7 +19,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::defaults::default_log_level;
-use super::defaults::default_msr_enabled;
 use super::defaults::default_report_hashrate;
 use crate::*;
 
@@ -57,7 +56,6 @@ pub struct UnresolvedOptimizations {
     #[serde(flatten)]
     pub randomx: UnresolvedRandomX,
 
-    #[serde(default = "default_msr_enabled")]
     pub msr_config: MSRConfig,
 
     pub threads_per_core: Option<usize>,

--- a/crates/msr/Cargo.toml
+++ b/crates/msr/Cargo.toml
@@ -20,3 +20,5 @@ nix.workspace = true
 once_cell.workspace = true
 raw-cpuid.workspace = true
 tracing.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/msr/src/lib.rs
+++ b/crates/msr/src/lib.rs
@@ -57,21 +57,21 @@ pub type MSRResult<T> = Result<T, MSRError>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MSRConfig {
-    pub enable_msr: bool,
+    pub msr_enabled: bool,
     pub original_msr_preset: MSRCpuPreset,
 }
 
 impl MSRConfig {
-    pub fn new(enable_msr: bool, original_msr_preset: MSRCpuPreset) -> MSRConfig {
+    pub fn new(msr_enabled: bool, original_msr_preset: MSRCpuPreset) -> MSRConfig {
         Self {
-            enable_msr,
+            msr_enabled,
             original_msr_preset,
         }
     }
 
     pub fn disabled_msr() -> MSRConfig {
         Self {
-            enable_msr: false,
+            msr_enabled: false,
             original_msr_preset: MSRCpuPreset::new(vec![]),
         }
     }

--- a/crates/msr/src/lib.rs
+++ b/crates/msr/src/lib.rs
@@ -68,8 +68,10 @@ impl MSRConfig {
             original_msr_preset,
         }
     }
+}
 
-    pub fn disabled_msr() -> MSRConfig {
+impl Default for MSRConfig {
+    fn default() -> Self {
         Self {
             msr_enabled: false,
             original_msr_preset: MSRCpuPreset::new(vec![]),

--- a/crates/msr/src/msr_cpu_preset_x86_64.rs
+++ b/crates/msr/src/msr_cpu_preset_x86_64.rs
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::msr_cpu_preset::MSRCpuPreset;
+
+use once_cell::sync::Lazy;
+
+/// This global is used with Linux x86_64 only to look for the original
+/// MSR state only once.
+static CPU_MSR_ORIGINAL_PRESET: Lazy<MSRCpuPreset> = Lazy::new(|| {
+    use crate::msr_cpu_preset::get_cpu_preset;
+    use crate::msr_item::MSRItem;
+    use crate::msr_mode::detect_msr_mode;
+    use crate::MSRConfig;
+    use crate::MSRImpl;
+
+    let core_id = 0.into();
+    let mode = detect_msr_mode();
+    let preset = get_cpu_preset(mode);
+    let msr_config = MSRConfig::new(true, preset.clone());
+    let msr = MSRImpl::new(msr_config, core_id);
+    let original_items = preset
+        .get_valid_items()
+        .map(|preset_item| {
+            let item = msr.read(preset_item.register_id(), core_id);
+            if let Ok(item) = item {
+                item
+            } else {
+                // Adding an invalid Item to effectively disable the MSR
+                MSRItem::new(0, 0)
+            }
+        })
+        .collect();
+    MSRCpuPreset::new(original_items)
+});
+
+pub fn get_original_cpu_msr_preset() -> MSRCpuPreset {
+    CPU_MSR_ORIGINAL_PRESET.clone()
+}

--- a/crates/msr/src/msr_cpu_preset_x86_64.rs
+++ b/crates/msr/src/msr_cpu_preset_x86_64.rs
@@ -20,7 +20,7 @@ use once_cell::sync::Lazy;
 
 /// This global is used with Linux x86_64 only to look for the original
 /// MSR state only once.
-static CPU_MSR_ORIGINAL_PRESET: Lazy<MSRCpuPreset> = Lazy::new(|| {
+pub(crate) static CPU_MSR_ORIGINAL_PRESET: Lazy<MSRCpuPreset> = Lazy::new(|| {
     use crate::msr_cpu_preset::get_cpu_preset;
     use crate::msr_item::MSRItem;
     use crate::msr_mode::detect_msr_mode;

--- a/crates/msr/src/msr_item.rs
+++ b/crates/msr/src/msr_item.rs
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-#[derive(Clone, Copy, Debug)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MSRItem {
     register_id: u32,
     value: u64,

--- a/crates/msr/src/msr_mode.rs
+++ b/crates/msr/src/msr_mode.rs
@@ -40,6 +40,7 @@ pub fn detect_msr_mode() -> MSRMode {
         _ => MSRModNone,
     }
 }
+
 fn detect_amd_msr_mode(cpuid: &CpuId<CpuIdReaderNative>) -> MSRMode {
     use MSRMode::*;
 

--- a/crates/msr/src/msr_non_x86_64.rs
+++ b/crates/msr/src/msr_non_x86_64.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+/// This module is no-op implementation to allow the code to compile on non-x86_64 archs.
 use cpu_utils::LogicalCoreId;
 
 use crate::MSRResult;
@@ -40,4 +41,16 @@ impl MSR for MSRImpl {
     fn restore(self) -> MSRResult<()> {
         Ok(())
     }
+}
+
+pub fn detect_msr_mode() -> MSRMode {
+    MSRModNone
+}
+
+pub fn get_original_cpu_msr_preset() -> MSRCpuPreset {
+    use crate::msr_cpu_preset::CPU_MSR_PRESETS;
+    use msr_mode::MSRMode;
+
+    let mode = MSRMode::MSRModNone;
+    get_cpu_preset(mode).clone()
 }

--- a/crates/msr/src/msr_x86_64.rs
+++ b/crates/msr/src/msr_x86_64.rs
@@ -156,8 +156,6 @@ impl MSR for MSRImpl {
             return Ok(());
         }
 
-        tracing::debug!("Restore MSR state.");
-
         for item in self.original_preset.get_valid_items() {
             self.write(*item, self.core_id)?;
         }


### PR DESCRIPTION
This is a patch for MSR original state persistence. It also fixes a bug with overwriting original value when multiple logical cores of the same phys core are used.