### PR TITLE
chore: bump ccp-randomx version before publishing

### DIFF
--- a/crates/randomx/Cargo.toml
+++ b/crates/randomx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccp-randomx"
 description = "RandomX Rust wrapper intended for the Fluence Capacity Commitment protocol"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This is to publish ccp-randomx