### PR TITLE
chore: fix ccp-randomx dependency version resolution issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "ccp-randomx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.4.2",
  "ccp-shared",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 [workspace.dependencies]
 capacity-commitment-prover = { path = "./ccp", version = "0.1.0" }
 ccp-config = { path = "./crates/config", version = "0.1.0" }
-ccp-randomx = { path = "./crates/randomx", version = "0.1.0"}
+ccp-randomx = { path = "./crates/randomx", version = "0.2.0"}
 ccp-msr = { path = "./crates/msr", version = "0.1.0" }
 ccp-rpc-client = { version = "0.1.0", path = "./crates/rpc-client" }
 ccp-rpc-server = { version = "0.1.0", path = "./crates/rpc-server" }


### PR DESCRIPTION
This is to fix the build failed b/c a suitable ccp-randomx version can not be found.