### PR TITLE
chore: change cpu_affinity package name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ccp_core_affinity"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a367f167e9434009f92a5638292e5ddbbe91af51b3d3446cf2ea96ac835d5e"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,21 +550,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "core_affinity"
-version = "0.8.1"
-source = "git+https://github.com/fluencelabs/core_affinity_rs#54d84297a1c2aad16b749b396f84db9bf7dceb0e"
-dependencies = [
- "libc",
- "num_cpus",
- "winapi",
-]
-
-[[package]]
 name = "cpu-utils"
 version = "0.4.2"
 dependencies = [
  "ccp-shared",
- "core_affinity",
+ "ccp_core_affinity",
  "hwlocality",
  "nonempty",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio-stream = {version = "0.1", features = ["fs"]}
 futures = "0.3"
 
 hwlocality = "1.0.0-alpha.1"
-core_affinity = { git = "https://github.com/fluencelabs/core_affinity_rs" }
+ccp_core_affinity = "0.8.1"
 
 anyhow = "1.0"
 byteorder = "1.5"

--- a/crates/cpu-utils/Cargo.toml
+++ b/crates/cpu-utils/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 ccp-shared.workspace = true
 
-core_affinity.workspace = true
+ccp_core_affinity.workspace = true
 hwlocality.workspace = true
 nonempty.workspace = true
 serde.workspace = true

--- a/crates/cpu-utils/src/pinning.rs
+++ b/crates/cpu-utils/src/pinning.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use core_affinity::CoreId;
+use ccp_core_affinity::CoreId;
 
 use crate::LogicalCoreId;
 
@@ -22,7 +22,7 @@ use crate::LogicalCoreId;
 /// Returns true, if pinning was successful.
 pub fn pin_current_thread_to(core_id: LogicalCoreId) -> bool {
     let core_id = CoreId { id: core_id.into() };
-    core_affinity::set_for_current(core_id)
+    ccp_core_affinity::set_for_current(core_id)
 }
 
 /// Lightweight function which doesn't require topology to pin current thread to the specified
@@ -36,5 +36,5 @@ pub fn pin_current_thread_to_cpuset(core_ids: impl Iterator<Item = LogicalCoreId
         })
         .collect::<Vec<_>>();
 
-    core_affinity::set_mask_for_current(&core_ids)
+    ccp_core_affinity::set_mask_for_current(&core_ids)
 }


### PR DESCRIPTION
This patch should fix cargo publishing in the CI to fix [this issue](https://github.com/fluencelabs/capacity-commitment-prover/actions/runs/8224597850/job/22488619394).
