### PR TITLE
feat(rpc,ccp): health check calls

### DIFF
--- a/ccp/src/hashrate/prometheus.rs
+++ b/ccp/src/hashrate/prometheus.rs
@@ -39,6 +39,10 @@ async fn handler_404() -> impl response::IntoResponse {
     (http::StatusCode::NOT_FOUND, "No such endpoint")
 }
 
+async fn health(_: State<PrometheusMetrics>) -> impl response::IntoResponse {
+    (http::StatusCode::OK, "OK")
+}
+
 async fn handle_metrics(
     State(state): State<PrometheusMetrics>,
 ) -> response::Result<http::Response<body::Body>> {
@@ -84,6 +88,7 @@ async fn run_prometheus_endpoint(
     let state = PrometheusMetrics { hashrate_collector };
     let app = axum::Router::new()
         .route("/metrics", get(handle_metrics))
+        .route("/health", get(health))
         .fallback(handler_404)
         .with_state(state);
     log::info!("Starting a prometheus endpoint at {prometheus_listen_address:?}");

--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -67,6 +67,9 @@ pub trait CCPRpc {
 
     #[method(name = "realloc_utility_cores", param_kind = map)]
     async fn realloc_utility_cores(&self, utility_core_ids: Vec<LogicalCoreId>);
+
+    #[method(name = "health")]
+    async fn health(&self) -> Result<String, ErrorObjectOwned>;
 }
 
 pub struct CCPRpcHttpClient {
@@ -112,5 +115,9 @@ impl CCPRpcHttpClient {
         utility_core_ids: Vec<LogicalCoreId>,
     ) -> Result<(), ClientError> {
         CCPRpcClient::realloc_utility_cores(&self.inner, utility_core_ids).await
+    }
+
+    pub async fn health(&self) -> Result<String, ClientError> {
+        CCPRpcClient::health(&self.inner).await
     }
 }

--- a/crates/rpc-server/src/lib.rs
+++ b/crates/rpc-server/src/lib.rs
@@ -169,4 +169,9 @@ where
         let guard = self.cc_prover.lock().await;
         guard.realloc_utility_cores(utility_core_ids).await;
     }
+
+    #[instrument(skip(self))]
+    async fn health(&self) -> Result<String, ErrorObjectOwned> {
+        Ok("OK".to_owned())
+    }
 }


### PR DESCRIPTION
The RPC endpoint has now `health() -> String` call, and Prometheus endpoint has a `/health` check.