### PR TITLE
fix(rpc)!: Fine-grain CCProver locks

### DIFF
--- a/ccp/src/alignment_roadmap/roadmap_alignable.rs
+++ b/ccp/src/alignment_roadmap/roadmap_alignable.rs
@@ -18,10 +18,12 @@ use super::CCProverAlignmentRoadmap;
 
 pub trait RoadmapAlignable: Send {
     type Error: Send;
+    type ProofCache;
 
     /// Apply the given roadmap (a set of actions) to align Nox and CCP states.
     fn align_with(
         &mut self,
         roadmap: CCProverAlignmentRoadmap,
+        proof_cache: Self::ProofCache,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 }

--- a/ccp/src/alignment_roadmap/tests.rs
+++ b/ccp/src/alignment_roadmap/tests.rs
@@ -20,8 +20,8 @@ use rand::rngs::SmallRng;
 use rand::Rng;
 
 use ccp_shared::types::CUAllocation;
-use ccp_shared::types::CUID;
 use ccp_shared::types::PhysicalCoreId;
+use ccp_shared::types::CUID;
 use ccp_test_utils::test_values as test;
 
 use super::CCProverAlignmentRoadmap;

--- a/ccp/src/hashrate/handler.rs
+++ b/ccp/src/hashrate/handler.rs
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-use ccp_shared::types::LogicalCoreId;
+use parking_lot::Mutex;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Mutex;
+
+use ccp_shared::types::LogicalCoreId;
 
 use super::HResult;
 use super::HashrateCollector;
@@ -54,7 +55,7 @@ impl HashrateHandler {
     }
 
     pub(crate) fn account_record(&mut self, record: ThreadHashrateRecord) -> HResult<()> {
-        let mut guard = self.collector.lock().unwrap();
+        let mut guard = self.collector.lock();
 
         if let EpochObservation::EpochChanged {
             prev_epoch_hashrate,
@@ -73,12 +74,12 @@ impl HashrateHandler {
     }
 
     pub(crate) fn proof_found(&mut self, core_id: LogicalCoreId) {
-        let mut guard = self.collector.lock().unwrap();
+        let mut guard = self.collector.lock();
         guard.proof_found(core_id)
     }
 
     pub(crate) fn handle_cum_tick(&self) -> HResult<()> {
-        let guard = self.collector.lock().unwrap();
+        let guard = self.collector.lock();
         let hashrate = guard.collect();
         self.saver.save_hashrate_current(hashrate)
     }

--- a/ccp/src/proof_storage.rs
+++ b/ccp/src/proof_storage.rs
@@ -34,7 +34,7 @@ impl ProofStorageDrainer {
 
     /// Removes all proofs in the proof directory, it's intended for cleanup storage
     /// when a new epoch happened.
-    pub async fn remove_proofs(&self) -> tokio::io::Result<()> {
+    pub async fn remove_proofs(&mut self) -> tokio::io::Result<()> {
         if tokio::fs::try_exists(&self.proof_directory).await? {
             tokio::fs::remove_dir_all(&self.proof_directory).await?;
         }

--- a/ccp/src/prover.rs
+++ b/ccp/src/prover.rs
@@ -49,7 +49,6 @@ use crate::proof_storage::ProofStorageDrainer;
 use crate::state_storage::CCPState;
 use crate::state_storage::StateStorage;
 use crate::status::CCStatus;
-use crate::status::ToCCStatus;
 use crate::utility_thread::UtilityThread;
 
 const PROOF_DIR: &str = "cc_proofs";
@@ -113,12 +112,6 @@ impl NoxCCPApi for CCProver {
 
     async fn realloc_utility_cores(&self, utility_core_ids: Vec<LogicalCoreId>) {
         self.utility_core_ids_handle.set_cores(utility_core_ids);
-    }
-}
-
-impl ToCCStatus for CCProver {
-    async fn status(&self) -> CCStatus {
-        self.state.lock().await.status
     }
 }
 

--- a/ccp/src/prover/tests.rs
+++ b/ccp/src/prover/tests.rs
@@ -97,7 +97,7 @@ fn load_state(state_dir: &Path) -> Option<CCPState> {
 async fn prover_on_active_commitment() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
 
-    let mut prover = get_prover(state_dir.path()).await;
+    let prover = get_prover(state_dir.path()).await;
     let epoch_params = get_epoch_params();
     let cu_allocation = get_cu_allocation();
     prover
@@ -156,7 +156,7 @@ async fn prover_on_active_commitment() {
 async fn prover_on_no_active_commitment() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
 
-    let mut prover = get_prover(state_dir.path()).await;
+    let prover = get_prover(state_dir.path()).await;
     prover.on_no_active_commitment().await.unwrap();
 
     let proofs = prover
@@ -172,7 +172,7 @@ async fn prover_on_no_active_commitment() {
 #[ignore = "until on_no_active_commitment cleans proofs_dir"]
 async fn prover_on_active_no_active_commitment() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
-    let mut prover = get_prover(state_dir.path()).await;
+    let prover = get_prover(state_dir.path()).await;
     let epoch_params = get_epoch_params();
     let cu_allocation = get_cu_allocation();
 
@@ -210,7 +210,7 @@ async fn prover_on_active_no_active_commitment() {
 async fn prover_on_active_reduce_allocation_on_active_commitment() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
 
-    let mut prover = get_prover(state_dir.path()).await;
+    let prover = get_prover(state_dir.path()).await;
     let mut cu_allocation = get_cu_allocation();
     let epoch_params = get_epoch_params();
     prover
@@ -233,7 +233,7 @@ async fn prover_on_active_reduce_allocation_on_active_commitment() {
 async fn prover_on_active_reduce_empty_allocation_active_commitment() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
 
-    let mut prover = get_prover(state_dir.path()).await;
+    let prover = get_prover(state_dir.path()).await;
     let mut cu_allocation = get_cu_allocation();
     prover
         .on_active_commitment(get_epoch_params(), cu_allocation.clone())
@@ -268,7 +268,7 @@ async fn prover_on_active_reduce_empty_allocation_active_commitment() {
 async fn prover_on_active_extend_allocation_on_active_commitment() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
 
-    let mut prover = get_prover(state_dir.path()).await;
+    let prover = get_prover(state_dir.path()).await;
     let mut cu_allocation = get_cu_allocation();
 
     prover
@@ -296,7 +296,7 @@ async fn prover_on_active_extend_allocation_on_active_commitment() {
 async fn prover_on_active_reschedule_on_active_commitment() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
 
-    let mut prover = get_prover(state_dir.path()).await;
+    let prover = get_prover(state_dir.path()).await;
     let mut cu_allocation = get_cu_allocation();
 
     prover
@@ -324,7 +324,7 @@ async fn prover_on_active_reschedule_on_active_commitment() {
 async fn prover_on_active_extend_on_active_commitment_performance() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
 
-    let mut prover = get_prover(state_dir.path()).await;
+    let prover = get_prover(state_dir.path()).await;
     let cu_allocation_large = get_cu_allocation();
     let cu_allocation_small = hashmap! {
         1.into() => cu_allocation_large.get(&1.into()).cloned().unwrap(),
@@ -368,7 +368,7 @@ async fn prover_on_active_extend_on_active_commitment_performance() {
 async fn prover_on_active_change_epoch() {
     let state_dir = tempdir::TempDir::new("state").unwrap();
 
-    let mut prover = get_prover(state_dir.path()).await;
+    let prover = get_prover(state_dir.path()).await;
     let cu_allocation = get_cu_allocation();
 
     let epoch_params_first = get_epoch_params();

--- a/ccp/src/prover/tests.rs
+++ b/ccp/src/prover/tests.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use ccp_config::CCPConfig;
+use ccp_config::Tokio;
 use ccp_config::Workers;
 use ccp_randomx::ResultHash;
 use ccp_shared::proof::{CCProof, CCProofId, ProofIdx};
@@ -46,6 +47,7 @@ async fn get_prover(state_dir: impl Into<PathBuf>) -> CCProver {
         logs: <_>::default(),
         state_dir,
         workers: Workers::default(),
+        tokio: Tokio::default(),
     };
 
     CCProver::new(config).await.unwrap()
@@ -60,6 +62,7 @@ async fn get_prover_from_saved_state(state_dir: impl Into<PathBuf>) -> CCProver 
         logs: <_>::default(),
         state_dir,
         workers: Workers::default(),
+        tokio: Tokio::default(),
     };
 
     let utility_core_ids_handle = CpuIdsHandle::new(vec![2.into()]);

--- a/ccp/src/prover/tests.rs
+++ b/ccp/src/prover/tests.rs
@@ -111,7 +111,7 @@ async fn prover_on_active_commitment() {
         epoch_params,
         cu_allocation: cu_allocation.clone(),
         msr_state: <_>::default(),
-        utility_cores: vec![1.into()],
+        utility_cores: vec![],
     });
 
     tokio::time::sleep(GEN_PROOFS_DURATION).await;
@@ -398,7 +398,7 @@ async fn prover_on_active_change_epoch() {
         epoch_params: epoch_params_second,
         cu_allocation: cu_allocation.clone(),
         msr_state: <_>::default(),
-        utility_cores: vec![1.into()],
+        utility_cores: vec![],
     });
 
     tokio::time::sleep(GEN_PROOFS_DURATION).await;

--- a/ccp/src/status.rs
+++ b/ccp/src/status.rs
@@ -22,7 +22,3 @@ pub enum CCStatus {
     Running { epoch: EpochParameters },
     Idle,
 }
-
-pub trait ToCCStatus {
-    fn status(&self) -> impl std::future::Future<Output = CCStatus> + Send;
-}

--- a/ccp/src/status.rs
+++ b/ccp/src/status.rs
@@ -24,5 +24,5 @@ pub enum CCStatus {
 }
 
 pub trait ToCCStatus {
-    fn status(&self) -> CCStatus;
+    fn status(&self) -> impl std::future::Future<Output = CCStatus> + Send;
 }

--- a/crates/config/src/tests/tests_.rs
+++ b/crates/config/src/tests/tests_.rs
@@ -19,12 +19,13 @@ use std::path::PathBuf;
 use ccp_randomx::RandomXFlags;
 
 use crate::config_loader::load_config;
-use crate::unresolved_config::UnresolvedWorkers;
 use crate::CCPConfig;
 use crate::Logs;
 use crate::Optimizations;
 use crate::RpcEndpoint;
 use crate::ThreadsPerCoreAllocationPolicy;
+use crate::Tokio;
+use crate::Workers;
 
 #[test]
 fn parse_basic_config() {
@@ -36,7 +37,8 @@ fn parse_basic_config() {
     let rpc_endpoint = RpcEndpoint {
         host: "127.0.0.1".to_string(),
         port: 9383,
-        utility_cores_ids: vec![1.into(), 2.into()],
+        facade_queue_size: 100,
+        utility_queue_size: 100,
     };
 
     let mut randomx_flags = RandomXFlags::default();
@@ -65,6 +67,7 @@ fn parse_basic_config() {
         logs,
         state_dir: "../test".into(),
         workers: Workers::default(),
+        tokio: Tokio::default(),
     };
 
     assert_eq!(actual_config, expected_config);
@@ -80,7 +83,8 @@ fn parse_config_without_optimiziations() {
     let rpc_endpoint = RpcEndpoint {
         host: "127.0.0.1".to_string(),
         port: 9383,
-        utility_cores_ids: vec![1.into(), 2.into()],
+        utility_queue_size: 100,
+        facade_queue_size: 100,
     };
 
     let randomx_flags = RandomXFlags::recommended_full_mem();
@@ -101,6 +105,7 @@ fn parse_config_without_optimiziations() {
         logs,
         state_dir: "../test".into(),
         workers: Workers::default(),
+        tokio: Tokio::default(),
     };
 
     assert_eq!(actual_config, expected_config);

--- a/crates/shared/src/nox_ccp_api.rs
+++ b/crates/shared/src/nox_ccp_api.rs
@@ -40,14 +40,14 @@ pub trait NoxCCPApi: Send {
     ///    after event from the on-chain part
     ///  - Nox (re)started
     fn on_active_commitment(
-        &mut self,
+        &self,
         epoch_parameters: EpochParameters,
         cu_allocation: CUAllocation,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 
     /// Stops all active jobs.
     fn on_no_active_commitment(
-        &mut self,
+        &self,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 
     /// Returns proofs after the provided proof idx for current epoch.


### PR DESCRIPTION
It allows to execute all RPC operations without waiting.

Now operations do not wait, but RPC operation may fail if internal queue is filled.  However, it should never happen under normal circumstances.