### PR TITLE
feat(shared): implement FromStr for shared types

### DIFF
--- a/crates/shared/src/types/cuid.rs
+++ b/crates/shared/src/types/cuid.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::str::FromStr;
+
 use hex::{FromHex, ToHex};
 use serde::{Deserialize, Serialize};
 
@@ -59,5 +61,13 @@ impl ToHex for CUID {
 impl std::fmt::Display for CUID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.encode_hex::<String>())
+    }
+}
+
+impl FromStr for CUID {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        FromHex::from_hex(s)
     }
 }

--- a/crates/shared/src/types/difficulty.rs
+++ b/crates/shared/src/types/difficulty.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::str::FromStr;
+
 use hex::{FromHex, ToHex};
 use serde::{Deserialize, Serialize};
 
@@ -71,5 +73,13 @@ impl ToHex for Difficulty {
 impl std::fmt::Display for Difficulty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.encode_hex::<String>())
+    }
+}
+
+impl FromStr for Difficulty {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        FromHex::from_hex(s)
     }
 }

--- a/crates/shared/src/types/global_nonce.rs
+++ b/crates/shared/src/types/global_nonce.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::str::FromStr;
+
 use hex::ToHex;
 use serde::Deserialize;
 use serde::Serialize;
@@ -60,5 +62,13 @@ impl ToHex for GlobalNonce {
 impl std::fmt::Display for GlobalNonce {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.encode_hex::<String>())
+    }
+}
+
+impl FromStr for GlobalNonce {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        FromHex::from_hex(s)
     }
 }

--- a/crates/shared/src/types/local_nonce.rs
+++ b/crates/shared/src/types/local_nonce.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::str::FromStr;
+
 use hex::{FromHex, ToHex};
 use serde::{Deserialize, Serialize};
 
@@ -77,5 +79,13 @@ impl ToHex for LocalNonce {
 impl std::fmt::Display for LocalNonce {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.encode_hex::<String>())
+    }
+}
+
+impl FromStr for LocalNonce {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        FromHex::from_hex(s)
     }
 }

--- a/crates/shared/src/types/result_hash.rs
+++ b/crates/shared/src/types/result_hash.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::str::FromStr;
+
 use hex::FromHex;
 use hex::ToHex;
 use serde::Deserialize;
@@ -71,5 +73,13 @@ impl ToHex for ResultHash {
 impl std::fmt::Display for ResultHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.encode_hex::<String>())
+    }
+}
+
+impl FromStr for ResultHash {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        FromHex::from_hex(s)
     }
 }


### PR DESCRIPTION
Together with Display, it allows to serialize and deserialize them as a string (using `serde_with`'s `DisplayFromStr`).