### PR TITLE
chore: publis rpc-server

### DIFF
--- a/crates/rpc-server/Cargo.toml
+++ b/crates/rpc-server/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
+publish = true
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
It seems it was set with `publish = false` by mistake.